### PR TITLE
Update metsoverview_it.md

### DIFF
--- a/web documents/metsoverview_it.md
+++ b/web documents/metsoverview_it.md
@@ -2,115 +2,34 @@
 
 ## Introduzione
 
-Curare una biblioteca di oggetti digitali significa gestirne,
-necessariamente, i relativi metadati. I metadati necessari, ad una
-gestione e ad un uso efficace degli oggetti digitali, sono diversi ed
-anche piu' numerosi, rispetto a quelli usati per manutenere collezioni
-di lavori a stampa o di altri oggetti fisici. Se una biblioteca puo'
-conservare i metadati descrittivi di un libro, il libro non si
-dissolvera' in una serie di pagine sconnesse, se la biblioteca dovesse
-incorrere in qualche errore nel memorizzare i metadati strutturali su
-come e' organizzato il libro, ne' gli studiosi saranno impossibilitati
-nel valutare il libro se la biblioteca dovesse sbagliare nell 'annotare
-che il libro e' stato prodotto usando una stampa offset Ryobi. Lo stesso
-non puo' dirsi per la versione digitale dello stesso libro. Senza i
-metadati strutturali, le immagini delle pagine o i file di testo di cui
-e' costituito un lavoro digitale sono di scarsa utilita', e senza i
-metadati tecnici riguardanti il processo di digitalizzazione, gli
-studiosi potrebbero essere insicuri su quanta rispondenza ci sia nella
-versione digitale rispetto all'originale. Inoltre, per necessita' di
-gestione interna, una biblioteca deve avere accesso a metadati tecnici
-appropriati per rinnovare e migrare periodicamente i dati, assicurando
-che la risorsa abbia un valore durevole.
+METS fornisce fornisce un'infrastruttura, per l'integrazione di insiemi complessi di metadati, che sono necessari al mantenimento di una biblioteca di oggetti digitali. Questi metadati possono sia estendere, quelli usati per gestire le collezioni di opera a stampa e di altri materiali fisici, che differenziarsi da essi. Ad esempio, un libro non si dissolve in una serie di pagine sconnesse, nel caso in cui il suo possessore dovesse incorrere in qualche errore nel memorizzare i metadati strutturali su come e' organizzato il libro, ne' gli studiosi sarebbero impossibilitati nel valutare il libro, se non fossero presenti le annotazioni riguardanti la sua produzione. Lo stesso non puo' dirsi per la versione digitale dello stesso libro. Senza i metadati strutturali, le immagini delle pagine o i file di testo di cui e' costituito un lavoro digitale sono di scarsa utilita', e senza i metadati tecnici riguardanti il processo di digitalizzazione, gli studiosi potrebbero non essere sicuri riguardo all'accuratezza della versione digitale, rispetto a quella dell'originale. Inoltre, per necessita' di gestione interna, un'organizzazione deve avere accesso a metadati tecnici appropriati per rinnovare e migrare periodicamente i dati, assicurando che la risorsa abbia un valore durevole.
 
-Il progetto [Making of America II](http://sunsite.berkeley.edu/MOA2/)
-(MOA2) ha gia' fronteggiato questi problemi in parte fornendo un formato
-per i metadati descrittivi, amministrativi e strutturali per lavori
-testuali e basati su immagini. METS, e' un'iniziativa della [Digital
-Library Federation](http://www.clir.org/diglib/) che, sulla scorta del
-progetto MOA2 , si propone di costruire, e di fornire, un formato di
-documento XML per codificare i metadati necessari sia per la gestione
-degli oggetti della biblioteca digitale contenuti in un deposito
-digitale, che per lo scambio di alcuni oggetti tra i depositi (o tra i
-depositi ed i loro utenti). In base al loro utilizzo, un documento METS
-potrebbe essere usato sia come Submission Information Package (SIP), sia
-come Archival Information Package (AIP), che come Dissemination
-Information Package (DIP) del modello di riferimento del [Open Archival
-Information System
-(OAIS)](http://ssdoo.gsfc.nasa.gov/nost/isoas/ref_model.html)
+Un documento METS e' costituito da sette sezioni principali:
 
-Un documento METS e' costituito da sette sezioni principali :
+1.  [**Intestazione METS**](#MHead) - Questa sezione contiene i metadati che descrivono il documento METS stesso, includendo alcune informazioni quali autore, editore, la data dell'ultima modifica, ecc.
 
-1.  [**Intestazione METS**](#MHead) - Questa sezione contiene i metadati
-    che descrivono il documento METS stesso, includendo alcune
-    informazioni quali autore, editore etc.
+2.  [**Metadati Descrittivi**](#descMD) - La sezione dei metadati descrittivi potrebbe sia puntare ad un documento METS esterno (p.e.,
+    un record MARC in un OPAC oppure un record EAD di uno strumento di ricerca gestito da un server web), che includere direttamente i metadati descrittivi, oppure prevedere entrambe le soluzioni (sia puntare ad una risorsa esterna, che includerli internamente). Inoltre, è possibile includere ripetizioni multiple di entrambi i metadati descrittivi (sia interni che esterni).
 
-2.  [**Metadati Descrittivi**](#descMD) - La sezione dei metadati
-    descrittivi potrebbe sia puntare ad un documento METS esterno (p.e.,
-    un record MARC in un OPAC oppure un EAD in cerca di aiuto gestito da
-    un server WWW), sia contenere metadati descrittivi inclusi
-    internamente oppure includerli entrambi. Sono ammesse anche
-    ripetizioni multiple di entrambi i metadati descrittivi , sia
-    interni che esterni .
+3.  [**Metadati Amministrativi**](#admMD) - La sezione dei metadati amministrativi contiene informazioni su come i files sono stati creati e archiviati, sui diritti di proprieta' intellettuale che sono ancora attivi, sull'oggetto di origine da cui deriva l'oggetto digitale, e sulla provenienza dei file che rappresentano gli oggetti digitali (ad esempio, le relazioni tra file master e file di derivazione, o le informazioni riguardanti la migrazione e la trasformazione). Analogamente ai metadati descrittivi, i metadati amministrativi possono essere sia puntati esternamente al documento METS, che codificati internamente.
 
-3.  [**Metadati Amministrativi**](#admMD) - La sezione dei metadati
-    amministrativi contiene sia informazioni sui files che sono stati
-    creati e che conservano i diritti di proprieta' intellettuale, sia
-    metadati riguardanti l'oggetto di origine da cui deriva l'oggetto
-    della biblioteca digitale , e sia informazioni riguardanti la
-    provenienza dei file e le relazioni degli oggetti della biblioteca
-    digitale (p.e. le relazioni dei file master e di derivazione, e le
-    informazioni riguardo la migrazione e la trasformazione). Allo
-    stesso modo dei metadati descrittivi, i metadati amministrativi
-    potrebbero essere sia esterni al documento METS, o codificati
-    internamente.
+4.  [**Sezione File**](#filegrp) - La sezione file e' costituita da una lista di tutti i file di contenuto e può comprendere le diverse versioni dell'oggetto digitale. Gli elementi `<file>` possono essere raggruppati all'interno di elementi `<fileGrp>`, per suddividerli in base alle diverse versioni.
 
-4.  [**Sezione File**](#filegrp) - La sezione file e' una lista di tutti
-    i file contenenti il contenuto che comprende le versioni
-    elettroniche dell'oggetto digitale .  Gli elementi `<file>`
-    potrebbero essere raggruppati all'interno di elementi `<fileGrp>`,
-    per fare una suddivisione in base alle diverse versioni degli
-    oggetti.
+5.  [**Mappa Strutturale**](#structmap) - La mappa strutturale e' il cuore del documento METS, ed è l'unica sezione obbligatoria dello stesso. Essa mette in evidenza la struttura gerarchica a cui appartiene l'oggetto digitale, e collega gli elementi di quella struttura ai file di contenuto ed ai metadati appartenenti ad ogni elemento. Lo schema METS, permette di includere nel documento più mappe strutturali.
 
-5.  [**Mappa Strutturale**](#structmap) - La mappa strutturale e' il
-    cuore del documento METS. Essa mette in evidenza la struttura
-    gerarchica a cui appartiene l'oggetto della biblioteca digitale, e
-    collega gli elementi di quella struttura ai file di contenuto ed ai
-    metadati appartenenti ad ogni elemento.
+6.  [**Link Strutturali**](#structlink) - La sezione dei link strutturali METS permette, a chi crea il METS, di memorizzare l'esistenza di hyperlink tra i nodi della gerarchia, descritta dalla sezione della mappa strutturale. Cio' e' di particolare importanza, quando METS viene usato per archiviare siti web.
 
-6.  [**Link Strutturali**](#structlink) - La sezione dei link
-    strutturali METS permette ad un autore METS di memorizzare
-    l'esistenza di hyperlink tra nodi nella gerarchia definita nella
-    Mappa strutturale. Cio' e' di particolare importanza nell'uso di
-    METS per archiviare siti web.
+7.  [**Comportamento**](#behavior) - Una sezione di comportamento puo' essere usata per associare i comportamenti al contenuto
+    dell'oggetto METS. Ogni comportamento, descritto in questa sezione, ha un elemento di definizione di interfaccia che rappresenta una
+    definizione astratta dell'insieme di comportamenti rappresentati da una particolare sezione comportamento. Ogni comportamento ha anche un elemento di meccanismo che identifica un modulo di codice eseguibile, che implementa ed esegue i comportamenti definiti, in modo  astratto dalla definizione dell'interfaccia.
 
-7.  [**Comportamento**](#behavior) - Una sezione di comportamento puo'
-    essere usata per associare comportamenti con il contenuto
-    dell'oggetto METS. Ogni comportamento, contenuto in questa sezione,
-    ha un elemento di definizione di interfaccia che rappresenta una
-    definizione astratta dell'insieme di comportamenti rappresentati da
-    una particolare sezione comportamento. Ogni comportamento ha anche
-    un elemento di meccanismo che identifica un modulo di codice
-    eseguibile che implementa ed esegue i comportamenti definiti in modo
-    astratto dalla definizione dell'interfaccia.
-
-Segue un'ulteriore spiegazione di dettaglio per ogni sezione e per le
-relazioni che intercorrono tra di esse.
+Segue un'ulteriore spiegazione di dettaglio per ogni sezione e per le relazioni che intercorrono tra di esse.
 
 ## <span id="MHead">Intestazione METS</span>
 
-<span id="#MHead">L'elemento di intestazione del METS permette di
-memorizzare i metadati descrittivi minimi sull'oggetto METS stesso
-all'interno di un documento METS.   Tali metadati includono la data di
-creazione del documento METS, la data della sua ultima modifica, e lo
-status del documento METS.    In questa sezione vanno, inoltre
-memorizzati uno o piu' entita' che hanno avuto un ruolo particolare
-rispetto al documento METS, specificando il ruolo rivestito, ed
-aggiungendo una piccola nota riguardo la loro responsabilita'.  Inoltre,
-si possono memorizzare una varieta' di identificatori alternativi del
-documento METS, come supplemento all'identificatore primario per il
-documento METS memorizzato nell'attributo OBJID dell'elemento root.  Un
-esempio dell'intestazione METS potrebbe essere il seguente:  
+<span id="#MHead">L'elemento di intestazione del METS permette di memorizzare i metadati descrittivi minimi sull'oggetto METS stesso
+all'interno di un documento METS. Tali metadati includono la data di creazione del documento METS, la data della sua ultima modifica, e lo status del documento METS. In questa sezione vengono inoltre memorizzati uno o piu' entita', che hanno avuto un ruolo particolare,
+rispetto al documento METS, specificandone il ruolo rivestito, ed aggiungendo una piccola nota riguardo la loro responsabilita'.  Inoltre, si possono memorizzare una varieta' di identificatori alternativi del documento METS, come supplemento all'identificativo primario per il documento METS memorizzato nell'attributo OBJID dell'elemento root. Un esempio dell'intestazione METS potrebbe essere il seguente:  
 </span>
 
 ```xml
@@ -124,30 +43,14 @@ esempio dell'intestazione METS potrebbe essere il seguente:
 </metsHdr>         
 ```
 
-<span id="#MHead">Tale esempio contiene due attributi sull'elemento
-`<metsHdr>` , CREATEDATE and RECORDSTATUS, che sono utilizzati per
-indicare la data e l'ora in cui il record METS e' stato creato, e lo
-status di elaborabozione del record.  Vengono elencate, inoltre, due
-entita' individuali del record METS, la persona responsabile di aver
-creato il record e quella responsabile per il materiale originale. 
-Entrambi gli attributi "ROLE" e "TYPE" nell'elemento `<agent>` usano un
-vocabolario controllato.  I valori possibili per l'attributo ROLE
-includono "ARCHIVIST", "CREATOR", "CUSTODIAN", "DISSEMINATOR", "EDITOR",
-"IPOWNER" ed "OTHER"  I valori per l'attributo TYPE possono essere
-"INDIVIDUAL" , "ORGANIZATION" or "OTHER."</span>
+<span id="#MHead">Tale esempio contiene due attributi sull'elemento `<metsHdr>` , CREATEDATE e RECORDSTATUS, che sono utilizzati per
+indicare la data e l'ora in cui il record METS e' stato creato, e lo status di elaborazione del record.  Vengono elencate, inoltre, due entita' individuali del record METS, la persona responsabile di aver creato il record e quella responsabile per il materiale originale. Entrambi gli attributi "ROLE" e "TYPE" nell'elemento `<agent>` usano un vocabolario controllato. I valori possibili per l'attributo ROLE includono "ARCHIVIST", "CREATOR", "CUSTODIAN", "DISSEMINATOR", "EDITOR", "IPOWNER" ed "OTHER". I valori per l'attributo TYPE possono essere "INDIVIDUAL" , "ORGANIZATION" o "OTHER."</span>
 
 ## <span id="descMD">Metadati Descrittivi</span>
 
-La sezione dei metadati descrittivi di un documento METS e' costituita
-da uno o piu' elementi `<dmdSec>` (Descriptive Metadata Section) . Ogni
-elemento `<dmdSec>` potrebbe sia contenere un puntatore a metadati
-esterni (elemento `<mdRef>`), che includere i metadati internamente
-(nell'elemento `<mdWrap>` ), oppure puo' contenerli entrambi.
+La sezione dei metadati descrittivi di un documento METS e' costituita da uno o piu' elementi `<dmdSec>` (Descriptive Metadata Section). Ogni elemento `<dmdSec>` potrebbe sia contenere un puntatore a metadati esterni (elemento `<mdRef>`), che includere i metadati internamente (nell'elemento `<mdWrap>`), oppure puo' contenerli entrambi.
 
-**I metadati descrittivi esterni (mdRef):** un elemento mdRef fornisce
-un URI che indentifica la locazione dei metadati esterni. Per esempio,
-il seguente riferimento di metadati punta ad un particolare oggetto
-della biblioteca digitale:
+**I metadati descrittivi esterni (mdRef):** un elemento mdRef fornisce un URI che identifica la locazione dei metadati esterni. Per esempio, il seguente riferimento di metadati punta ad un particolare oggetto digitale:
 
 ```xml 
 <dmdSec ID="dmd001">
@@ -156,30 +59,11 @@ della biblioteca digitale:
 </dmdSec>       
 ```
 
-L'elemento `<mdRef>` di questa `<dmdSec>` contiene quattro attributi.
-L'attributo LOCTYPE specifica il tipo di locatore contenuto nel corpo
-dell'elemnto; valori validi per LOCTYPE includono 'URN', 'URL', 'PURL',
-'HANDLE', 'DOI', e 'OTHER'. L'attributo MIMETYPE specifica il tipo MIME
-per i metadati descrittivi esterni, ed MDTYPE indica che forma di
-metadati sono contenuti. Valori validi per l'elemento MDTYPE sono MARC,
-MODS, EAD, VRA (VRA Core), DC (Dublin Core), NISOIMG (NISO Technical
-Metadata for Digital Still Images), LC-AV (Library of Congress
-Audiovisual Metadata) , TEIHDR (TEI Header), DDI (Data Documentation
-Initiative), FGDC (Federal Geographic Data Committee Metadata Standard
-\[FGDC-STD-001-1998\] ), e OTHER. LABEL fornisce il meccanismo per
-descrivere questi metadati a coloro che visualizzano il documento METS,
-per esempio la visualizzazione del documento in una 'Tabella di
-contenuti' .
+L'elemento `<mdRef>` di questa `<dmdSec>` contiene quattro attributi. L'attributo LOCTYPE specifica il tipo di locatore contenuto nel corpo dell'elemento; valori validi per LOCTYPE includono 'URN', 'URL', 'PURL', 'HANDLE', 'DOI', e 'OTHER'. L'attributo MIMETYPE specifica il tipo MIME per i metadati descrittivi esterni, e MDTYPE indica il formato dei metadati. Valori validi per l'elemento MDTYPE sono MARC, MODS, EAD, VRA (VRA Core), DC (Dublin Core), NISOIMG (NISO Technical Metadata for Digital Still Images), LC-AV (Library of Congress Audiovisual Metadata) , TEIHDR (TEI Header), DDI (Data Documentation Initiative), FGDC (Federal Geographic Data Committee Metadata Standard \[FGDC-STD-001-1998\] ), e OTHER. 
+LABEL fornisce il meccanismo per descrivere questi metadati a coloro che visualizzano il documento METS, per esempio la visualizzazione del documento in una 'Tabella di contenuti'.
 
-**I metadati descrittivi interni (mdWrap):** Un elemento mdWrap e' un
-contenitore dei dati inseriti direttamente nel documento METS. Tali
-metadati possono assumere due forme: 1. codificati in XML-encoded , con
-il codice identificativo dell'XML stesso come appartenente ad un
-namespace diverso da quello del METS oppure 2. qualsiasi arbitraria
-forma binaria o di testo, considerato che i metadati sono codificati
-come Base64 e contenuti in un elemento `<binData>` all'interno
-dell'elemento mdWrap. I seguenti esempi mostrano l'uso dell'elemento
-mdWrap :
+**I metadati descrittivi interni (mdWrap):** Un elemento mdWrap e' un contenitore dei dati inseriti direttamente nel documento METS. Tali metadati possono assumere due forme: 1) codificati in XML, con il codice identificativo dell'XML stesso appartenente ad un namespace diverso da quello del METS, oppure 2) qualsiasi arbitraria forma binaria o di testo, considerato che i metadati sono codificati come Base64 e contenuti in un elemento `<binData>` all'interno dell'elemento mdWrap. 
+I seguenti esempi mostrano l'uso dell'elemento mdWrap:
 
 ```xml
 <dmdSec ID="dmd002">
@@ -203,49 +87,15 @@ mdWrap :
 </dmdSec>           
 ```
 
-E' da notare che tutti gli elementi `<dmdSec>` devono possedere un
-attributo ID. Questo attributo e' un identificativo univoco interno per
-ogni elemento `<dmdSec>` che puo' essere usato nella mappa strutturale
-per collegare una particolare divisione della gerarchia del documento ad
-un particolare elemento `<dmdSec>`. Cio' permette a sezioni specifiche
-di metadati descrittivi di essere collegati a parti specifiche
-dell'oggetto digitale.
+E' da notare che tutti gli elementi `<dmdSec>` devono possedere un attributo ID. Questo attributo e' un identificativo univoco interno per ogni elemento `<dmdSec>`, e che puo' essere usato nella mappa strutturale per collegare una particolare divisione della gerarchia del documento, ad un particolare elemento `<dmdSec>`. Cio' permette a sezioni specifiche di metadati descrittivi di essere collegati a parti specifiche dell'oggetto digitale.
 
 ## <span id="admMD">Metadati Amministrativi</span>
 
-Gli elementi `<amdSec>` contengono i metadati amministrativi relativi ai
-file che costituiscono l'oggetto della biblioteca digitale come quelli
-relativi ai file usati per creare l'oggetto dal materiale originale di
-provenienza. Ci sono quattro tipologie principali di metadati
-amministrativi per un documento METS: 1. metadati tecnici (informazioni
-riguardanti la creazione, il formato e le caratteristiche di utilizzo),
-2. metadati sulla proprieta' intellettuale (copyright e informazioni
-sulle licenze d'uso), 3. Metadati dell'origine (descrittivi ed
-amministrativi riguardanti l'origine analogica di derivazione
-dell'oggetto della biblioteca digitale), e 4. metadati della provenienza
-digitale (informazioni sulle relazioni dei file sorgente e di
-destinazione, sulle relazioni tra file master e di derivazione e sui
-file impiegati nella migrazione/trasformazione tra la digitalizzazione
-originale di un artefatto e la sua attuale "incarnazione" come oggetto
-della biblioteca digitale ).  Ognuna di queste quattro diverse tipologie
-di metadati amministrativi ha un unico subelemento all'interno
-dell'elemento `<amdSec>`, in cui poter inserire i metadati specifici :
-`<techMD>`, `<rightsMD>`, `<sourceMD>` e `<digiprovMD>`.  Ognuno di
-questi elementi potrebbe ripetersi piu' di una volta in un documento
-METS.
+Gli elementi `<amdSec>` contengono sia i metadati amministrativi, relativi ai file che costituiscono l'oggetto digitale, che quelli
+relativi al materiale originale di provenienza. Ci sono quattro tipologie principali di metadati amministrativi per un documento METS: 1) metadati tecnici (informazioni riguardanti la creazione, il formato e le caratteristiche di utilizzo), 2) metadati sulla proprieta' intellettuale (copyright e informazioni sulle licenze d'uso), 3) metadati riguardanti l'origine (descrittivi ed amministrativi riguardanti l'origine analogica di derivazione dell'oggetto digitale), e 4) metadati sulla provenienza digitale (informazioni sulle relazioni dei file sorgente e di quelli di destinazione, sulle relazioni tra file master e di derivazione e sui file impiegati nella migrazione/trasformazione tra la digitalizzazione originale di un artefatto e la sua "incarnazione" come oggetto digitale). Ognuna di queste quattro diverse tipologie di metadati amministrativi, ha un subelemento di `<amdSec>`, dedicato all'inserimento dei metadati specifici: `<techMD>`, `<rightsMD>`, `<sourceMD>` e `<digiprovMD>`.  Ognuno di questi elementi potrebbe ripetersi piu' di una volta in un documento METS.
 
-Gli elementi `<techMD>`, `<rightsMD>`, `<sourceMD>` e `<digiprovMD>`
-seguono lo stesso modello di contenuto dell'elemento `<dmdSec>`: essi
-potrebbero contenere un elemento `<mdRef>` per puntare ai metadati
-amministrativi esterni, oppure usare un elemento `<mdWrap>` per i
-metadati amministrativi presenti internamente, oppure essere utilizzati
-entrambi. Istanze multiple di questi elementi potrebbero ripetersi, ed
-ognuno di loro deve essere corredato di un attributo ID in modo che gli
-altri elementi del documento METS (cosi' come le divisioni della mappa
-strutturale o come gli elementi `<file>`) possano essere collegati ai
-sottoelementi `<amdSec>` a cui si riferiscono. Si potrebbe, per esempio,
-avere un elemento `<techMD>` che include i metadati tecnici riguardanti
-le modalita' di produzione di un file:
+Gli elementi `<techMD>`, `<rightsMD>`, `<sourceMD>` e `<digiprovMD>` seguono lo stesso modello di contenuto dell'elemento `<dmdSec>`: essi potrebbero contenere un elemento `<mdRef>` per puntare ai metadati amministrativi esterni, oppure usare un elemento `<mdWrap>` per i metadati amministrativi interni, oppure essere utilizzati entrambi. Istanze multiple di queste sottosezioni potrebbero ripetersi, ed
+ognuna di loro deve essere corredata di un attributo ID, in modo che altri elementi del documento METS (cosi' come le divisioni della mappa strutturale o come gli elementi `<file>`) possano essere collegati ai sottoelementi `<amdSec>` a cui si riferiscono. Si potrebbe, per esempio, avere un elemento `<techMD>` che include i metadati tecnici riguardanti le modalita' di produzione di un file:
 
 ```xml
 <techMD ID="AMD001">
@@ -261,9 +111,7 @@ le modalita' di produzione di un file:
 </techMD>
 ```
 
-Un elemento `<file>` all'interno di `<fileGrp>` potrebbe successivamente
-identificare questi metadati amministrativi come appartenenti al file
-attraverso l'attributo ADMID, che punta all'elemento `<techMD>` :
+Un elemento `<file>` all'interno di `<fileGrp>` potrebbe successivamente identificare questi metadati amministrativi come appartenenti al file attraverso l'attributo ADMID, che punta all'elemento `<techMD>`:
 
 ```xml
 <file ID="FILE001" ADMID="AMD001">
@@ -273,18 +121,11 @@ attraverso l'attributo ADMID, che punta all'elemento `<techMD>` :
 
 ## <span id="filegrp">Sezione File</span>
 
-La sezione file (`<fileSec>`) contiene uno o piu' elementi `<fileGrp>`
-usati per raggruppare i file correlati. Un elemento `<fileGrp>` fornisce
-un elenco di tutti i file che costituiscono una singola versione
-elettronica dell'oggetto della biblioteca digitale. Per esempio,
-potrebbero essere separate da elementi `<fileGrp>` le immagini per le
-gallerie di immagini, quelle master di archivio e le versioni pdf, le
-versioni TEI, etc.
+La sezione file (`<fileSec>`) contiene uno o piu' elementi `<fileGrp>` usati per raggruppare i file correlati. Un elemento `<fileGrp>` fornisce l'elenco di tutti i file che costituiscono una singola versione elettronica dell'oggetto digitale. Per esempio,
+potrebbero essere separate da elementi `<fileGrp>` le immagini per le gallerie di immagini, quelle master di archivio e le versioni pdf, le versioni TEI, etc.
 
-Consideriamo l'esempio che segue come una sezione file da un oggetto
-della biblioteca digitale di un racconto orale di cui si hanno tre
-diverse versioni: una trascrizione a codifica TEI, un file master audio
-in formato WAV, ed un file di derivazione in formato MP3:
+Consideriamo l'esempio che segue, come una sezione file, da un oggetto digitale di un racconto orale di cui si hanno tre
+diverse rappresentazioni: una trascrizione a codifica TEI, un file master audio in formato WAV, ed un file di derivazione in formato MP3:
 
 ```xml 
 <fileSec>
@@ -308,63 +149,19 @@ in formato WAV, ed un file di derivazione in formato MP3:
 </fileSec>
 ```
 
-In questo caso la `<fileSec>` contiene tre elementi di raggruppamento
-`<fileGrp>`, uno per ogni differente versione dell'oggetto. Il primo e'
-il file trascritto in codice XML, il secondo e' un master audio in
-formato Wav ed il terzo e' il derivato in formato MP3. Sebbene in tale
-esempio, gli elementi `<fileGrp>` per distinguere le differenti versioni
-non sembrino essere utili, `<fileGrp>` diventa molto piu' utile per
-oggetti costituiti da un numero cospicuo di immagini di pagine
-digitalizzate o invece in altri casi dove una singola versione e'
-costituita da un numero ingente di file. In quei casi, e' necessario
-suddividere gli elementi `<file>` nei `<fileGrp>` per identificare i
-file appartenenti ad una versione particolare del documento.
+In questo caso la `<fileSec>` contiene tre elementi di raggruppamento `<fileGrp>`, uno per ogni rappresentazione dell'oggetto. Il primo e' il file trascritto in codice XML, il secondo e' un master audio in formato Wav ed il terzo e' il derivato in formato MP3. Sebbene in tale esempio, gli elementi `<fileGrp>` per distinguere le diverse rappresentazioni non sembrino essere utili, `<fileGrp>` diventa molto piu' utile per oggetti costituiti da un numero cospicuo di immagini di pagine digitalizzate o invece in altri casi dove una singola rappresentazione e' costituita da un numero ingente di file. In quei casi, e' necessario suddividere gli elementi `<file>` nei `<fileGrp>` per identificare i file appartenenti ad una rappresentazione specifica del documento.
 
-Si puo' notare la presenza dell'attributo GROUPID con un valore identico
-per i due elementi per i file audio `<file>`; cio' sta ad indicare che i
-due file, dal momento che appartengono a diverse versioni dell'oggetto,
-contengono le stesse informazioni di base (e' possibile usare GROUPID
-allo stesso modo, per indicare i file immagine di pagine equivalenti per
-quegli oggetti che sono costituiti da molte immagini digitalizzate).
+Si puo' notare la presenza dell'attributo GROUPID con un valore identico per i due elementi per i file audio `<file>`; cio' sta ad indicare che i due file, dal momento che appartengono a diverse rappresentazioni dell'oggetto, contengono le stesse informazioni di base (e' possibile usare GROUPID allo stesso modo, per indicare i file immagine di pagine equivalenti per quegli oggetti digitali che sono costituiti da molte immagini digitalizzate).
 
-E' da notare, inoltre, che gli elementi `<file>` hanno un attributo ID
-univoco. Tale attributo costituisce un nome univoco, a cui possono fare
-riferimento le altre parti del documento. Un esempio del meccanismo di
-riferimento e' visibile nella sezione della Mappa Strutturale.
+E' da notare, inoltre, che gli elementi `<file>` hanno un attributo ID univoco. Tale attributo costituisce un nome univoco, a cui possono fare riferimento le altre parti del documento. Un esempio del meccanismo di riferimento e' visibile nella sezione della Mappa Strutturale.
 
-Va menzionato che gli elementi `<file>`potrebbero possedere un elemento
-`<FContent>` invece di un elemento `<FLocat>`. Gli elementi `<FContent>`
-vengono usati per inserire i contenuti veri e propri del file nel
-documento METS, e devono essere codificati in formato XML o Base64. Dal
-momento che i file incorporati non sono qualcosa che abitualmente viene
-usato per preparare un documento METS allo scopo di mostrare un oggetto
-della biblioteca digitale all'utente, cio' puo' essere una
-caratteristica di una certa importanza per lo scambio di oggetti della
-biblioteca digitale tra depositi digitali, o per archiviare le diverse
-versioni degli stessi a scopo conservativo.
+E' da notare che gli elementi `<file>` potrebbero possedere un elemento `<FContent>` invece di un elemento `<FLocat>`. Gli elementi `<FContent>` vengono usati per inserire i contenuti veri e propri del file nel documento METS, e devono essere codificati in formato XML o Base64. Sebbene incorporare i file non sia una pratica molto comune per preparare un documento METS, con lo scopo di mostrare un oggetto della biblioteca digitale all'utente, cio' puo' essere una caratteristica di una certa importanza per lo scambio di oggetti digitali tra depositi, o per archiviare le diverse versioni degli stessi a scopo conservativo.
 
 ## <span id="structmap">Mappa Strutturale</span>
 
-La sezione della mappa strutturale di un documento METS definisce la
-struttura gerarchica degli oggetti della biblioteca digitale da
-presentare all'utente, in modo da permettergli di consultarli.
-L'elemento `<structMap>` codifica tale gerarchia con una serie
-nidificata di elementi `<div>`. Ogni elemento `<div>` e' corredato di un
-attributo informativo che specifica di che tipo di divisione si tratta,
-ed inoltre, puo' contenere puntatori METS multipli (`<mptr>`) e
-puntatori ad elementi file (`<fptr>`) per identificare il contenuto
-corrispondente a quella specifica divisione `<div>`. I puntatori METS
-specificano documenti METS separati come contenitori di informazioni di
-rilievo sul file per quella `<div>` che li contiene . Cio' puo' essere
-utile per codificare ampie collezioni di materiali (p.e. un intero
-giornale ) conservando traccia delle dimensioni di ogni file METS in un
-insieme relativamente piccolo. I puntatori ai file specificano i file (o
-in alcuni casi , sia gruppi di file , che locazioni specifiche
-all'interno di un file) all'interno del documento METS corrente. La
-sezione `<fileSec>`corrisponde alla parte di gerarchia rappresentata
-dalla `<div>` corrente.
+La sezione della mappa strutturale di un documento METS definisce la struttura gerarchica degli oggetti digitali da presentare all'utente, in modo da permettergli di consultarli. L'elemento `<structMap>` codifica tale gerarchia con una serie nidificata di elementi `<div>`. Ogni elemento `<div>` e' corredato di un attributo informativo che specifica di che tipo di divisione si tratta, ed inoltre, puo' contenere puntatori METS multipli (`<mptr>`) e puntatori ad elementi file (`<fptr>`) per identificare il contenuto corrispondente a quella specifica divisione `<div>`. I puntatori METS specificano documenti METS separati, come contenitori di informazioni del file, specifiche per la `<div>` che li contiene. Cio' puo' essere utile per codificare ampie collezioni di materiali (ad esempio, un intero giornale) conservando traccia delle dimensioni di ogni file METS, in un insieme relativamente piccolo. I puntatori ai file specificano i file (o in alcuni casi, sia gruppi di file, che locazioni specifiche all'interno di un file) all'interno del documento METS corrente. La sezione `<fileSec>`corrisponde alla parte di gerarchia rappresentata dalla `<div>` che ne collega gli identificativi.
 
-Di seguito viene fornito l'esempio di una semplice mappa strutturale:
+Di seguito, l'esempio di una semplice mappa strutturale:
 
 ```xml 
 <structMap TYPE="logical">
@@ -406,45 +203,18 @@ Di seguito viene fornito l'esempio di una semplice mappa strutturale:
 </structMap>
 ```
 
-Questa mappa strutturale definisce la gerarchia di un racconto orale
-(del sindaco di New York City Abraham Beame ) che comprende tre
-sottosezioni : la presentazione introduttiva dell'intervistatore, alcuni
-racconti familiari da Mayor Beame ed un dibattito di come e' stato
-coinvolto dall'unione degli insegnanti di New York. Ognuna delle
-sottosezioni/divisioni e' collegata a tre file (presi dall'esempio
-precedente "file groups" della sezione file) : una trascrizione in
-codice XML, un master audio in formato Wav ed il derivato in formato
-MP3. Un elemento sussidiario `<area>` viene usato in ogni `<fptr>` per
-indicare che tale divisione corrisponde solo ad una parte del file
-collegato e per identificare la parte specifica di ogni file collegato.
-Per esempio, la prima divisione (l'introduzione dell'intervistatore ) e'
-collegata alla parte del file di trascrizione XML (FILE001) che si trova
-tra due tag con l'attributo ID uguale a "INTVWBG" e "INTVWND." Essa ,
-inoltre, e' collegata a due differenti file audio; in questi casi
-piuttosto che specificare il valore attibuto ID all'interno dei file
-collegati, i punti d'inizio e di fine del materiale collegato
-all'interno dei file sono indicati da un semplice codice di
-temporizzazione nel formato HH:MM:SS. Cosi', l'introduzione
-dell'intervistatore, puo' essere trovata in entrambi i file audio e nel
-segmento individuato dal punto iniziale con cronometro uguale a
-00:00:00, fino ad arrivare al tempo cronometrico di 00:01:47.
+Questa mappa strutturale definisce la gerarchia di un racconto orale (del sindaco di New York City Abraham Beame) e che comprende tre
+sottosezioni: la presentazione introduttiva dell'intervistatore, alcuni racconti familiari del Sindaco Beame, ed un dibattito su come e' stato coinvolto dall'unione degli insegnanti di New York.
+Ognuna delle sottosezioni/divisioni e' collegata a tre file (presi dall'esempio precedente "file groups" della sezione file): una trascrizione in codice XML, un master ed un file audio derivato. L'elemento sussidiario `<area>`, viene usato in ogni `<fptr>` per
+indicare che questa divisione corrisponde solo ad una parte del file collegato e per identificare la parte specifica di ogni file collegato. Per esempio, la prima divisione (l'introduzione dell'intervistatore ) e' collegata alla parte del file di trascrizione XML (FILE001) che si trova tra due tag identificate rispettivamente da "INTVWBG" e "INTVWND". La prima divisione è inoltre collegata, a due differenti file audio; in questi casi piuttosto che specificare gli identificativi (ID) dell'attributo all'interno dei file
+collegati, i punti d'inizio e di fine del materiale collegato all'interno dei file sono indicati da un semplice codice di temporizzazione nel formato HH:MM:SS. Cosi', l'introduzione dell'intervistatore, puo' essere trovata in entrambi i file audio e nel
+segmento individuato dal punto iniziale con cronometro uguale a 00:00:00, fino ad arrivare al tempo cronometrico di 00:01:47.
 
 ## <span id="structlink">Link Strutturali</span>
 
-La sezione dei link strutturali del formato METS e' la piu' semplice tra
-le altre sezioni principali del documento METS, dal momento che contiene
-un singolo elemento `<smLink>` (sebbene tale elemento possa essere
-ripetuto).  La sezione dei link strutturali del METS e' stata creata per
-permettere di memorizzare la presenza di hyperlink tra gli elementi
-costitutivi di una mappa strutturale `<div>` .  Questa e' un'utile
-facility se si vuole utilizzare lo standard METS per archiviare siti web
-e conservarne la struttura ipertestuale, separatamente dai file HTML del
-sito stesso.
+La sezione dei link strutturali del formato METS e' la piu' semplice tra le altre sezioni principali del documento METS, dal momento che contiene un singolo elemento `<smLink>` (sebbene tale elemento possa essere ripetuto). La sezione dei link strutturali del METS e' stata creata per permettere di memorizzare la presenza di hyperlink tra gli elementi costitutivi di una mappa strutturale `<div>`. Questo meccanismo facilita l'utilizzo dello standard METS per archiviare siti web e per conservarne la struttura ipertestuale, separatamente dai file HTML del sito stesso.
 
-Facendo un esempio, consideriamo il caso di un documento METS per una
-pagina web contenente un'immagine che e' collegata con un hyperlink ad
-un'altra pagina.  L'elemento `<structMap>` probabilmente conterrebbe
-divisioni `<div>` come le seguenti:
+Facendo un esempio, consideriamo il caso di un documento METS per una pagina web contenente un'immagine che e' collegata con un hyperlink ad un'altra pagina.  L'elemento `<structMap>` probabilmente conterrebbe divisioni `<div>`, come nell'esempio seguente:
 
 ```xml 
 <div ID="P1" TYPE="page" LABEL="Page 1">
@@ -459,10 +229,7 @@ divisioni `<div>` come le seguenti:
 </div>
 ```
 
-Se si volesse indicare che il file immagine nella `<div>` contenuta
-nella prima pagina, `<div>` viene collegata al file HTML della seconda
-pagina `<div>`, si avrebbe un elemento `<smLink>` all'interno della
-sezione `<structLink>` del documento METS:
+Se si volesse indicare che il file immagine nella `<div>` contenuta nella prima pagina, `<div>` viene collegata al file HTML della seconda pagina `<div>`, si avrebbe un elemento `<smLink>` all'interno della sezione `<structLink>` del documento METS:
 
 ```xml 
 <smLink xlink:from="IMG1" xlink:to="P2" xlink:title="Hyperlink from 
@@ -470,29 +237,14 @@ sezione `<structLink>` del documento METS:
   xlink:actuate="onRequest" />
 ```
 
-L'elemento `<smLink>` usa una forma leggermente modificata della
-sintassi XLink; vengono usati tutti gli attributi XLink ma gli attributi
-"to" e "from" sono dichiarati per essere di tipo IDREF piuttosto che
-NMTOKEN come la specifica originale XLink . Cio' ci permette di indicare
-l'esistenza di link tra due nodi qualsiasi nella mappa strutturale ed
-inoltre di usare gli strumenti XML di processing per dare conferma che
-il nodo collegato esista realmente.
+L'elemento `<smLink>` usa una forma leggermente modificata della sintassi XLink; vengono usati tutti gli attributi XLink ma gli attributi "to" e "from" sono dichiarati per essere di tipo IDREF piuttosto che NMTOKEN come la specifica originale XLink. Cio' ci permette di indicare l'esistenza di link tra due nodi qualsiasi, nella mappa strutturale, ed inoltre di usare gli strumenti XML di processamento per dare conferma che il nodo collegato esista realmente.
 
 ## <span id="behavior">Sezione Comportamento</span>
 
-Una sezione comportamento puo' essere usata per associare comportamenti
-eseguibili, al contenuto dell 'oggetto METS. Una sezione comportamento
-contiene uno o piu' elementi `<behavior>`, ognuno dei quali ha un
-definizione di interfaccia che rappresenta una definizione astratta
-dell'insieme di comportamenti rappresentati in una particolare sezione.
-Un `<behavior>`, inoltre, ha un elemento `<mechanism>` che viene usato
-per puntare ad un modulo di codice eseguibile che implementa ed esegue
-il comportamento definito in modo astratto dalla definizione di
-interfaccia.
+Una sezione comportamento puo' essere usata per associare comportamenti eseguibili, al contenuto dell'oggetto METS. Una sezione comportamento contiene uno o piu' elementi `<behavior>`, ognuno dei quali ha una definizione di interfaccia che rappresenta una definizione astratta dell'insieme di comportamenti rappresentati in una particolare sezione.
+Una sezione `<behavior>` ha, inoltre, un elemento `<mechanism>` che viene usato per puntare ad un modulo di codice eseguibile che implementa ed esegue il comportamento definito in modo astratto dalla definizione di interfaccia.
 
-I comportamenti degli oggetti digitali possono essere implementati come
-collegamenti a servizi web distribuiti come nell'esempio seguente
-fornito dal progetto della Mellon [Fedora](http://www.fedora.info/) .
+I comportamenti degli oggetti digitali possono essere implementati come collegamenti a servizi web, distribuiti come nell'esempio seguente fornito dal progetto della Mellon [Fedora](http://www.fedora.info/).
 
 ```xml 
 <behavior ID="DISS1.1" STRUCTID="S1.1" BTYPE="uva-bdef:stdImage"
@@ -527,26 +279,14 @@ Altri riferimenti utili per questa sezione :
 
 ## Conclusione
 
-Lo schema METS definisce un meccanismo flessibile per la codifica di
-metadati descrittivi, amministrativi e strutturali per gli oggetti di
-una biblioteca digitale, e per documentare le relazioni complesse tra le
-varie forme di metadati . Esso puo', inoltre, fornire un utile standard
-per lo scambio tra depositi di oggetti appartenenti alla biblioteca
-digitale . Infine, lo schema METS offre la capacita' di associare un
-oggetto digitale a comportamenti o servizi. La presente trattazione,
-mette in risalto le principali caratteristiche dello schema, ma
-un'approfondita disamina dello schema e della sua documentazione inclusa
-e' necessaria per capirne l'ampio spettro di potenzialita'.
+Lo schema METS definisce un meccanismo flessibile per la codifica di metadati descrittivi, amministrativi e strutturali per gli oggetti digitali, e per documentare le relazioni complesse tra i vari formati di metadati. Esso puo', inoltre, fornire un utile standard
+per lo scambio tra depositi, di oggetti digitali. Infine, lo schema METS offre la capacita' di associare un oggetto digitale a comportamenti o servizi. Questo tutorial, mette in risalto le principali caratteristiche dello schema METS, ma un'approfondita disamina dello schema e della sua documentazione inclusa, si rende necessaria per capirne l'ampio spettro di potenzialita'.
 
 -----
 
-Questo documento corrisponde alla traduzione del documento "[**METS: An
-Overview &
-Tutorial**](//www.loc.gov/standards/mets/METSOverview.v2.html)",
+Questo documento è la traduzione del documento "[**METS: An Overview & Tutorial**](//www.loc.gov/standards/mets/METSOverview.v2.html)",
 pubblicato il 2 Giugno 2004.  
-La traduzione è stata curata da [Angela Di
-Iorio](/cdn-cgi/l/email-protection#92f3fcf5f7fef3bcf6fbfbfde0fbfdd2e7fcfbe0fdfff3a3bcfbe6)
-nel corso del progetto per la biblioteca digitale
-([S.I.M.B.A.D.](http://web-serv.provincia.campobasso.it/biblioteca/digitale/)),
-realizzato per la Biblioteca Provinciale "P. Albino" di Campobasso
-(Italia).
+La traduzione è stata curata da [Angela Di Iorio](/cdn-cgi/l/email-protection#92f3fcf5f7fef3bcf6fbfbfde0fbfdd2e7fcfbe0fdfff3a3bcfbe6)
+nel corso del progetto per la biblioteca digitale ([S.I.M.B.A.D.](http://web-serv.provincia.campobasso.it/biblioteca/digitale/)),
+realizzato per la Biblioteca Provinciale "P. Albino" di Campobasso (Italia).
+La traduzione, è stata aggiornata nel Maggio 2019.


### PR DESCRIPTION
I reviewed the whole Italian translation and I made all necessary changes, according to the current version of the METS tutorial. I just want to highlight that I changed the "version" term in the file section into "representation".
Specifically in the following paragraphs:
"Consider the following example of a file section from a digital object for an oral history which has three different versions:"
and
"while belonging to different versions of the object"
